### PR TITLE
Add GPT-Rosalind article with fallback image

### DIFF
--- a/src/content/articles/gpt-rosalind.en.md
+++ b/src/content/articles/gpt-rosalind.en.md
@@ -1,0 +1,32 @@
+---
+title: "GPT-Rosalind"
+title_en: "GPT-Rosalind"
+slug: gpt-rosalind
+date: 2026-04-19
+author: Facundo Uferer
+category: Life Sciences AI
+tags:
+  - AI
+  - Biotech
+  - Medicine
+  - Research
+excerpt: OpenAI presentó GPT-Rosalind para investigación en ciencias de la vida y refuerza la transición de modelos generales hacia herramientas verticales de alto valor.
+excerpt_en: OpenAI introduced GPT-Rosalind for life sciences research, reinforcing the shift from general-purpose models toward high-value vertical tools.
+readingTime: 4
+lang: en
+published: true
+featured: false
+---
+![Default article image](/img/articles/imagenotfound.png)
+
+# GPT-Rosalind
+
+OpenAI introduced GPT-Rosalind, a model **specialized for life sciences research** with which it aims to enter one of the most promising businesses in applied AI: accelerating drug discovery without having to wait a decade for every breakthrough. The company defines it as a system oriented toward biology, chemistry, genomics, and translational medicine, capable of assisting with tasks such as literature review, hypothesis generation, experimental planning, and scientific data analysis. In other words: fewer hours navigating PDFs, more hours arguing about whether the model actually understood the paper. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+The name is not accidental. GPT-Rosalind pays tribute to **Rosalind Franklin**, a key figure in the discovery of DNA structure. OpenAI is trying to combine historical branding with a clear market signal: this product is not meant to write slogans or answer awkward emails, but to insert itself into labs, pharmaceutical companies, and R&D teams where every week saved can be worth millions. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+According to the company, the model improves reasoning about molecules, proteins, genes, and biological pathways, while also integrating better with external tools and specialized databases. It also launched a **free plugin for Codex** that connects with more than 50 scientific resources, a pragmatic move: in science, no model lives in isolation, and every promise eventually crashes into spreadsheets, broken repositories, and impossible formats. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+The initial version is already offered in “research preview” mode for qualified customers through ChatGPT, Codex, and the API. The partners mentioned include Amgen, Moderna, and Thermo Fisher Scientific, a sign that OpenAI is first targeting the high-budget enterprise segment rather than mass enthusiasm. Nobody gives away protein-simulation infrastructure for sport. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+The move confirms an increasingly visible trend: large general-purpose models are starting to fragment into vertical versions for specific sectors. After selling intelligence “for everything,” the next stage is selling intelligence “for something profitable.” And **few industries promise as much return as healthcare**.

--- a/src/content/articles/gpt-rosalind.es.md
+++ b/src/content/articles/gpt-rosalind.es.md
@@ -1,0 +1,32 @@
+---
+title: "GPT-Rosalind"
+title_en: "GPT-Rosalind"
+slug: gpt-rosalind
+date: 2026-04-19
+author: Facundo Uferer
+category: Life Sciences AI
+tags:
+  - AI
+  - Biotech
+  - Medicine
+  - Research
+excerpt: OpenAI presentó GPT-Rosalind para investigación en ciencias de la vida y refuerza la transición de modelos generales hacia herramientas verticales de alto valor.
+excerpt_en: OpenAI introduced GPT-Rosalind for life sciences research, reinforcing the shift from general-purpose models toward high-value vertical tools.
+readingTime: 4
+lang: es
+published: true
+featured: false
+---
+![Imagen por defecto del articulo](/img/articles/imagenotfound.png)
+
+# GPT-Rosalind
+
+OpenAI presentó GPT-Rosalind, un modelo **especializado para investigación en ciencias de la vida** con el que busca entrar de lleno en uno de los negocios más prometedores de la IA aplicada: acelerar el descubrimiento de fármacos sin tener que esperar una década por cada avance. La empresa lo define como un sistema orientado a biología, química, genómica y medicina traslacional, capaz de asistir en tareas como revisión bibliográfica, generación de hipótesis, planificación experimental y análisis de datos científicos. En otras palabras: menos horas navegando PDFs, más horas discutiendo si el modelo entendió realmente el paper. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+El nombre no es casual. GPT-Rosalind homenajea a **Rosalind Franklin**, figura clave en el descubrimiento de la estructura del ADN. OpenAI intenta así combinar branding histórico con una señal clara al mercado: este producto no está pensado para escribir slogans ni responder correos incómodos, sino para insertarse en laboratorios, farmacéuticas y equipos de I+D donde cada semana ganada puede valer millones. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+Según la compañía, el modelo mejora el razonamiento sobre moléculas, proteínas, genes y rutas biológicas, además de integrar mejor herramientas externas y bases de datos especializadas. También lanzó un **plugin gratuito para Codex** que conecta con más de 50 recursos científicos, una jugada pragmática: en ciencia, ningún modelo vive aislado y toda promesa termina enfrentándose a hojas de cálculo, repositorios rotos y formatos imposibles. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+La versión inicial ya se ofrece en modo “research preview” para clientes calificados a través de ChatGPT, Codex y la API. Entre los socios mencionados aparecen Amgen, Moderna y Thermo Fisher Scientific, señal de que OpenAI apunta primero al segmento corporativo de alto presupuesto antes que al entusiasmo masivo. Nadie regala infraestructura para simular proteínas por deporte. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
+
+El movimiento confirma una tendencia cada vez más visible: los grandes modelos generales empiezan a fragmentarse en versiones verticales para sectores concretos. Después de vender inteligencia “para todo”, llega la etapa de vender inteligencia “para algo rentable”. Y **pocas industrias prometen tanto retorno como la salud**.

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -111,6 +111,7 @@ const schema = buildArticleSchemas({
 		font-size: 1.1rem;
 		line-height: 1.85;
 		margin-top: 1.4rem;
+		text-align: justify;
 	}
 
 	.article-body :global(h1),

--- a/tests/issue-10-content-schema.test.mjs
+++ b/tests/issue-10-content-schema.test.mjs
@@ -15,5 +15,5 @@ test('project and article seed files exist', async () => {
 	const projects = await readdir('src/content/projects');
 	const articles = await readdir('src/content/articles');
 	assert.equal(projects.length, 6);
-	assert.equal(articles.length, 14);
+	assert.equal(articles.length, 16);
 });

--- a/tests/issue-15-article-layout.test.mjs
+++ b/tests/issue-15-article-layout.test.mjs
@@ -42,3 +42,9 @@ test('article layout renders bold markdown text with neon accent styling', async
 	assert.match(layout, /#F52D98/);
 	assert.match(layout, /text-shadow/);
 });
+
+test('article layout justifies article body text', async () => {
+	const layout = await readFile('src/layouts/ArticleLayout.astro', 'utf8');
+	assert.match(layout, /\.article-body\s*\{/);
+	assert.match(layout, /text-align: justify/);
+});

--- a/tests/issue-18-initial-articles-content.test.mjs
+++ b/tests/issue-18-initial-articles-content.test.mjs
@@ -123,6 +123,21 @@ test('vibe design article is split into localized files and references the provi
 	assert.match(enFile, /!\[Vibe Design\]\(\/img\/articles\/vivedesign\.png\)/);
 });
 
+test('gpt-rosalind article is split into localized files and uses the default article image', async () => {
+	await access('src/content/articles/gpt-rosalind.es.md');
+	await access('src/content/articles/gpt-rosalind.en.md');
+
+	const esFile = await readFile('src/content/articles/gpt-rosalind.es.md', 'utf8');
+	const enFile = await readFile('src/content/articles/gpt-rosalind.en.md', 'utf8');
+
+	assert.match(esFile, /lang: es|lang: 'es'|lang: "es"/);
+	assert.match(enFile, /lang: en|lang: 'en'|lang: "en"/);
+	assert.match(esFile, /published: true/);
+	assert.match(enFile, /published: true/);
+	assert.match(esFile, /!\[Imagen por defecto del articulo\]\(\/img\/articles\/imagenotfound\.png\)/);
+	assert.match(enFile, /!\[Default article image\]\(\/img\/articles\/imagenotfound\.png\)/);
+});
+
 test('all localized article files include an article image reference', async () => {
 	const files = [
 		'src/content/articles/ai-assisted-development-beyond-autocomplete.es.md',
@@ -139,6 +154,8 @@ test('all localized article files include an article image reference', async () 
 		'src/content/articles/the-final-irony.en.md',
 		'src/content/articles/vibe-design.es.md',
 		'src/content/articles/vibe-design.en.md',
+		'src/content/articles/gpt-rosalind.es.md',
+		'src/content/articles/gpt-rosalind.en.md',
 	];
 
 	for (const filePath of files) {


### PR DESCRIPTION
## Summary
- Add the bilingual GPT-Rosalind note as localized article files
- Use the default fallback image for the new note
- Justify article body text in the shared article layout
- Update content inventory and article asset coverage tests

## Testing
- `node --test tests/issue-10-content-schema.test.mjs tests/issue-18-initial-articles-content.test.mjs tests/issue-19-project-assets.test.mjs tests/issue-15-article-layout.test.mjs`
- `npm run astro -- check`