### PR TITLE
Remove redundant article headings from GPT-Rosalind and Vibe Design

### DIFF
--- a/src/content/articles/gpt-rosalind.en.md
+++ b/src/content/articles/gpt-rosalind.en.md
@@ -19,8 +19,6 @@ featured: false
 ---
 ![Default article image](/img/articles/imagenotfound.png)
 
-# GPT-Rosalind
-
 OpenAI introduced GPT-Rosalind, a model **specialized for life sciences research** with which it aims to enter one of the most promising businesses in applied AI: accelerating drug discovery without having to wait a decade for every breakthrough. The company defines it as a system oriented toward biology, chemistry, genomics, and translational medicine, capable of assisting with tasks such as literature review, hypothesis generation, experimental planning, and scientific data analysis. In other words: fewer hours navigating PDFs, more hours arguing about whether the model actually understood the paper. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
 
 The name is not accidental. GPT-Rosalind pays tribute to **Rosalind Franklin**, a key figure in the discovery of DNA structure. OpenAI is trying to combine historical branding with a clear market signal: this product is not meant to write slogans or answer awkward emails, but to insert itself into labs, pharmaceutical companies, and R&D teams where every week saved can be worth millions. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))

--- a/src/content/articles/gpt-rosalind.es.md
+++ b/src/content/articles/gpt-rosalind.es.md
@@ -19,8 +19,6 @@ featured: false
 ---
 ![Imagen por defecto del articulo](/img/articles/imagenotfound.png)
 
-# GPT-Rosalind
-
 OpenAI presentó GPT-Rosalind, un modelo **especializado para investigación en ciencias de la vida** con el que busca entrar de lleno en uno de los negocios más prometedores de la IA aplicada: acelerar el descubrimiento de fármacos sin tener que esperar una década por cada avance. La empresa lo define como un sistema orientado a biología, química, genómica y medicina traslacional, capaz de asistir en tareas como revisión bibliográfica, generación de hipótesis, planificación experimental y análisis de datos científicos. En otras palabras: menos horas navegando PDFs, más horas discutiendo si el modelo entendió realmente el paper. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))
 
 El nombre no es casual. GPT-Rosalind homenajea a **Rosalind Franklin**, figura clave en el descubrimiento de la estructura del ADN. OpenAI intenta así combinar branding histórico con una señal clara al mercado: este producto no está pensado para escribir slogans ni responder correos incómodos, sino para insertarse en laboratorios, farmacéuticas y equipos de I+D donde cada semana ganada puede valer millones. ([OpenAI](https://openai.com/index/introducing-gpt-rosalind/?utm_source=chatgpt.com "Introducing GPT-Rosalind for life sciences research"))

--- a/src/content/articles/vibe-design.en.md
+++ b/src/content/articles/vibe-design.en.md
@@ -19,8 +19,6 @@ featured: false
 ---
 ![Vibe Design](/img/articles/vivedesign.png)
 
-# Vibe Design
-
 Maybe the real bottleneck was never designing screens, but understanding what the hell the client actually needs. Anthropic’s launch of **Claude Design** pushes exactly in that direction: generating prototypes, presentations, one-pagers, and visual pieces from natural language, with the ability to learn the user’s brand and produce fast results in research preview mode. ([The Times of India](https://timesofindia.indiatimes.com/technology/tech-news/what-is-anthropics-claude-design-and-why-are-figma-and-adobe-stocks-dropping/articleshow/130341793.cms?utm_source=chatgpt.com "What is Anthropic's Claude Design, and why are Figma and Adobe stocks dropping"))
 
 The signal is clear. If an acceptable interface can appear in minutes, the value stops being in “drawing screens” and shifts toward defining problems, constraints, flows, business goals, compliance, brand tone, and real user needs. Put brutally: 90% of the process should be intelligent documentation and serious discovery; 10% should be rendering what was already well thought out. It is terrible news for people who confused Figma with strategy, and excellent news for people who know how to listen.

--- a/src/content/articles/vibe-design.es.md
+++ b/src/content/articles/vibe-design.es.md
@@ -19,8 +19,6 @@ featured: false
 ---
 ![Vibe Design](/img/articles/vivedesign.png)
 
-# Vibe Design
-
 Quizá el verdadero cuello de botella nunca fue diseñar pantallas, sino entender qué demonios necesita el cliente. El lanzamiento de Anthropic con **Claude Design** empuja justo en esa dirección: generar prototipos, presentaciones, one-pagers y piezas visuales desde lenguaje natural, con capacidad de aprender la marca del usuario y producir resultados rápidos en modo research preview. ([The Times of India](https://timesofindia.indiatimes.com/technology/tech-news/what-is-anthropics-claude-design-and-why-are-figma-and-adobe-stocks-dropping/articleshow/130341793.cms?utm_source=chatgpt.com "What is Anthropic's Claude Design, and why are Figma and Adobe stocks dropping"))
 
 La señal es clara. Si una interfaz aceptable puede aparecer en minutos, el valor deja de estar en “dibujar pantallas” y se desplaza hacia definir problemas, restricciones, flujos, objetivos comerciales, compliance, tono de marca y necesidades reales del usuario. Dicho brutalmente: el 90% del proceso debería ser documentación inteligente y descubrimiento serio; el 10%, renderizar lo que ya estaba bien pensado. Es una pésima noticia para quienes confundían Figma con estrategia, y una excelente noticia para quienes saben escuchar.


### PR DESCRIPTION
## Summary
- Removed duplicated H1 headings from the GPT-Rosalind and Vibe Design article bodies in both languages
- Kept the rendered article structure cleaner by relying on the page title already provided by the layout

## Testing
- Not run (not requested)